### PR TITLE
Remove alpha section from CHANGELOG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 name: CI
 
 on:
-- pull_request
-- workflow_dispatch
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+    # So you can add a label to make it run, including no-changeset-needed
+    - labeled
+    - unlabeled
 
 jobs:
   build-and-test:
@@ -62,6 +68,7 @@ jobs:
   changeset:
     runs-on: ubuntu-latest
     name: Changesets
+    if: ${{ (! startsWith(github.head_ref, 'changeset-release/')) && (!contains(github.event.pull_request.labels.*.name, 'no-changeset-needed')) }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -69,4 +76,3 @@ jobs:
         fetch-depth: 0
     - uses: ./.github/actions/node
     - run: npm run changeset-check
-      if: ${{ ! startsWith(github.head_ref, 'changeset-release/') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@
 
 - [#17](https://github.com/apollo-server-integrations/apollo-server-integration-express5/pull/17) [`94ea6bc`](https://github.com/apollo-server-integrations/apollo-server-integration-express5/commit/94ea6bc12aa20c583da15f440d3059ecd3c946a1) Thanks [@glasser](https://github.com/glasser)! - The package is now built for both CJS and ESM, instead of only for CJS; this is the same build approach taken by `@apollo/server`. This provides better compatibility with ESM-based build systems.
 
-## 1.1.0-alpha.0
-
-### Minor Changes
-
-- [#17](https://github.com/apollo-server-integrations/apollo-server-integration-express5/pull/17) [`94ea6bc`](https://github.com/apollo-server-integrations/apollo-server-integration-express5/commit/94ea6bc12aa20c583da15f440d3059ecd3c946a1) Thanks [@glasser](https://github.com/glasser)! - The package is now built for both CJS and ESM, instead of only for CJS; this is the same build approach taken by `@apollo/server`. This provides better compatibility with ESM-based build systems.
-
 ## 1.0.0
 
 ### Major Changes


### PR DESCRIPTION
Don't require changesets when you set a label (easier than `changeset --empty`)